### PR TITLE
Allow non-ip addr and resolve during flush

### DIFF
--- a/graphite.go
+++ b/graphite.go
@@ -15,7 +15,7 @@ import (
 // GraphiteConfig provides a container with configuration parameters for
 // the Graphite exporter
 type GraphiteConfig struct {
-	Addr          *net.TCPAddr     // Network address to connect to
+	Addr      string               // host:port to connect to
 	Registry      metrics.Registry // Registry to be exported
 	FlushInterval time.Duration    // Flush interval
 	DurationUnit  time.Duration    // Time conversion unit for durations
@@ -26,7 +26,7 @@ type GraphiteConfig struct {
 // Graphite is a blocking exporter function which reports metrics in r
 // to a graphite server located at addr, flushing them every d duration
 // and prepending metric names with prefix.
-func Graphite(r metrics.Registry, d time.Duration, prefix string, addr *net.TCPAddr) {
+func Graphite(r metrics.Registry, d time.Duration, prefix string, addr string) {
 	GraphiteWithConfig(GraphiteConfig{
 		Addr:          addr,
 		Registry:      r,
@@ -57,7 +57,11 @@ func GraphiteOnce(c GraphiteConfig) error {
 func graphite(c *GraphiteConfig) error {
 	now := time.Now().Unix()
 	du := float64(c.DurationUnit)
-	conn, err := net.DialTCP("tcp", nil, c.Addr)
+	addr, err := net.ResolveTCPAddr("tcp", c.Addr)
+	if nil != err {
+		return err
+	}
+	conn, err := net.DialTCP("tcp", nil, addr)
 	if nil != err {
 		return err
 	}

--- a/graphite_test.go
+++ b/graphite_test.go
@@ -17,14 +17,12 @@ func floatEquals(a, b float64) bool {
 }
 
 func ExampleGraphite() {
-	addr, _ := net.ResolveTCPAddr("net", ":2003")
-	go Graphite(metrics.DefaultRegistry, 1*time.Second, "some.prefix", addr)
+	go Graphite(metrics.DefaultRegistry, 1*time.Second, "some.prefix", ":2003")
 }
 
 func ExampleGraphiteWithConfig() {
-	addr, _ := net.ResolveTCPAddr("net", ":2003")
 	go GraphiteWithConfig(GraphiteConfig{
-		Addr:          addr,
+		Addr:          ":2003",
 		Registry:      metrics.DefaultRegistry,
 		FlushInterval: 1 * time.Second,
 		DurationUnit:  time.Millisecond,
@@ -66,7 +64,7 @@ func NewTestServer(t *testing.T, prefix string) (map[string]float64, net.Listene
 	r := metrics.NewRegistry()
 
 	c := GraphiteConfig{
-		Addr:          ln.Addr().(*net.TCPAddr),
+		Addr:          ln.Addr().String(),
 		Registry:      r,
 		FlushInterval: 10 * time.Millisecond,
 		DurationUnit:  time.Millisecond,


### PR DESCRIPTION
This PR allows a `hostname:port` string to be specified for `Addr` instead of a net.TCPAddr.

At first, I tried allowing both a `net.TCPAddr` and optionally a `string` for the server hostname, but it got messy, and I decided it wasn't worth it. 
